### PR TITLE
Fixed Offer validator on success & registration looks glitch

### DIFF
--- a/Cosmic/App/Controllers/Shop/Offers.php
+++ b/Cosmic/App/Controllers/Shop/Offers.php
@@ -60,12 +60,10 @@ class Offers
         if ($dedipass->status != 'success') {
             response()->json(["status" => "error", "message" => Locale::get('shop/offers/invalid_code')]);
         }
-      
-        $amount = Player::getCurrencys(request()->player->id)[$offer->currency_type]->amount;
   
         HotelApi::execute('givepoints', array('user_id' => request()->player->id, 'points' => $offer->amount, 'type' => $offer->currency));
         Log::addPurchaseLog(request()->player->id, $offer->amount . ' '.Locale::get('core/belcredits').' (' . $code . ')', $offer->lang);
-        response()->json(["status" => "success", "message" => Locale::get('shop/offers/success_1').' ' . $offer->amount . ' '.Locale::get('shop/offers/success_2')]);
+        response()->json(["status" => "success", "amount" => $offer->amount]);
     }
 
     public function index($offerid)

--- a/Cosmic/App/View/Home/registration.html
+++ b/Cosmic/App/View/Home/registration.html
@@ -196,11 +196,11 @@
                                     <img src="{{site.fpath}}/avatarimage?figure=hr-802-37.hd-185-1.ch-804-82.lg-280-73.sh-3068-1408-1408.wa-2001&amp;direction=4&amp;size=l" alt="Avatar" class="pixelated">
                                 </div>
                                 <div class="tabs-container">
-                                    <span class="selected" data-avatar="1"></span>
+                                    <span class="selected" data-avatar="0"></span>
+                                    <span data-avatar="1"></span>
                                     <span data-avatar="2"></span>
                                     <span data-avatar="3"></span>
                                     <span data-avatar="4"></span>
-                                    <span data-avatar="5"></span>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
Dedipass validator didn't return the correct expected result on success and the loading screen stayed forever.

On register, looks didn't work properly. Last button didn't work and look id 0 was unrecoverable once changed to another look.